### PR TITLE
skip processing when a PR is labeled when it is created.

### DIFF
--- a/app/views/repos.jade
+++ b/app/views/repos.jade
@@ -8,7 +8,7 @@ block content
 	unless repos == null
 		section(class="section--center mdl-grid")
 			each val in repos
-				div(class="mdl-card mdl-cell mdl-cell--12-col mdl-shadow--2dp")
+				div(class="mdl-card mdl-cell mdl-cell--4-col mdl-shadow--2dp")
 					div(class="mdl-card__title mdl-card--border")
 						h2(class="mdl-card__title-text")=val.name
 					div(class="mdl-card__menu")


### PR DESCRIPTION
- more to fix #18 when the PR is created with labels
- set up to respond to webhook when not processing so github knows that we are done, so it doesn't report as a timeout.