### PR TITLE
Topic/reactions api

### DIFF
--- a/app/bot.js
+++ b/app/bot.js
@@ -30,9 +30,8 @@ function unenforce(repo, callback) {
 
 function _setStatus ( repo, pr, approved, remaining, callback ) {
 	var status = approved ? "success" : "pending";
-	var desc = approved ? "The number of reviews needed was successfull." : "Waiting for " + remaining + " code reviews...";
-	console.log("setting status as : " + status);
-	console.log(desc);
+	var reviewsPluralized = remaining == 1 ? "review" : "reviews";
+	var desc = approved ? "The number of reviews needed was successfull." : "Waiting for " + remaining + " code " + reviewsPluralized + "...";
 	githubApi.webhooks.createStatus(repo, status, pr.head.sha, desc, function(err, reply) {
 		if(callback) {
 			callback(err,reply);

--- a/app/github.js
+++ b/app/github.js
@@ -5,6 +5,7 @@ var githubApi = require('./services/github/github-api'),
 	pullrequests = require('./services/github/pullrequests'),
 	comments = require('./services/github/comments'),
 	users = require('./services/github/users'),
+	reactions = require('./services/github/reactions'),
 	debug = require('debug')('reviewbot:bot'),
 	config = require('../config');
 
@@ -16,5 +17,6 @@ module.exports = {
 	pullrequests: pullrequests,
 	auth: auth,
 	comments: comments,
+	reactions: reactions,
 	users: users
 };

--- a/app/routes/pullrequest.js
+++ b/app/routes/pullrequest.js
@@ -70,7 +70,7 @@ var express = require('express'),
         console.log("POST Request received, but the PR is in a state that I do not care about (" + req.body.pull_request.state + ").");
         debug("POST Request received, but the PR is in a state that I do not care about (" + req.body.pull_request.state + ").");
         return _respond(res, "POST Request received, but the PR is in a state that I do not care about (" + req.body.pull_request.state + ").");
-    }
+    	}
 
       bot.checkForLabel(req.body.pull_request.number, repo, req.body.pull_request, processPullRequest);
       return _respond(res, 'Processing PR ' + req.body.pull_request.number);

--- a/app/services/github/github-api.js
+++ b/app/services/github/github-api.js
@@ -7,8 +7,11 @@ var github = new GitHubApi({
   protocol: "https",
   host: "api.github.com", // should be api.github.com for GitHub
   followRedirects: false, // default: true; there's currently an issue with non-get redirects, so allow ability to disable follow-redirects
-  timeout: 5000,
-	version: '3.0.0'
+  timeout: 8000,
+	version: '3.0.0',
+	headers: {
+		"Accept": "application/vnd.github.squirrel-girl-preview; */*"
+	}
 });
 
 module.exports = {

--- a/app/services/github/reactions.js
+++ b/app/services/github/reactions.js
@@ -1,0 +1,25 @@
+var githubApi = require('./github-api'),
+	github = githubApi.service,
+	auth = require('./auth'),
+	debug = require('debug')('reviewbot:bot'),
+	config = require('../../../config');
+
+function getForPullRequest(repo, prNumber, callback) {
+	if(!config.enableReactions) {
+		callback(null,[]);
+		return;
+	}
+	github.reactions.getForIssue({
+		user: config.organization,
+		repo: repo,
+		number: prNumber
+	}, function(err,res) {
+		if(callback) {
+			callback(err,res);
+		}
+	});
+}
+
+module.exports = {
+	getForPullRequest: getForPullRequest
+};

--- a/config.js
+++ b/config.js
@@ -27,6 +27,12 @@ config.instructionsComment = '';
 // labels that if the bot sees it will not monitor the PR.
 config.excludeLabels = ['no-review'];
 
+config.enableReactions = false;
+// the reactions that will identify as "looks good"
+config.lgtmReactions = ["+1", "heart", "hooray"];
+// the reactions that will identify as "needs work"
+config.needsWorkReactions = ["-1", "confused"];
+
 config.filenameFilter = '';
 // comment when the PR creator tries to approve their own PR.
 config.shameComment = ":bell: Shame! :bell: Shame!\nYou cannot vote to approve your own PR. 'A' for effort though.";


### PR DESCRIPTION
- added logic to process reactions. 
- reactions are disabled by default in the config
- github does not send a webhook when a reaction is added/removed. so it does not trigger a processing. This is why it is disabled.